### PR TITLE
Use string as backend instead of net.TCP

### DIFF
--- a/grafsy.toml
+++ b/grafsy.toml
@@ -5,8 +5,8 @@ clientSendInterval = 10
 metricsPerSecond = 1000
 
 carbonAddrs = [
-    "127.0.0.1:2003",
-    "127.0.0.1:2004",
+    "localhost:2003",
+    "localhost:2004",
 ]
 connectTimeout = 2
 

--- a/server.go
+++ b/server.go
@@ -92,9 +92,8 @@ func (s Server) aggrMetricsWithPrefix() {
 			}
 		}
 		if dropped > 0 {
-			for _, carbonAddrTCP := range s.Lc.carbonAddrsTCP {
-				backend := carbonAddrTCP.String()
-				s.Mon.Increase(&s.Mon.clientStat[backend].dropped, dropped)
+			for _, carbonAddr := range s.Conf.CarbonAddrs {
+				s.Mon.Increase(&s.Mon.clientStat[carbonAddr].dropped, dropped)
 			}
 		}
 	}
@@ -141,9 +140,8 @@ func (s Server) cleanAndUseIncomingData(metrics []string) {
 		}
 	}
 	if dropped > 0 {
-		for _, carbonAddrTCP := range s.Lc.carbonAddrsTCP {
-			backend := carbonAddrTCP.String()
-			s.Mon.Increase(&s.Mon.clientStat[backend].dropped, dropped)
+		for _, carbonAddr := range s.Conf.CarbonAddrs {
+			s.Mon.Increase(&s.Mon.clientStat[carbonAddr].dropped, dropped)
 		}
 	}
 }


### PR DESCRIPTION
If we use `carbonAddrTCP.String()`, then instead of hostname we have an IP:port, which isn't so good in case of ipv6.