### PR TITLE
Use init-system-helpers for systemd calls

### DIFF
--- a/packaging/postinst
+++ b/packaging/postinst
@@ -25,11 +25,7 @@ fi
 if [ ! -e "${CONF}" ]; then
   echo "For use this software you have to create ${CONF} file. You could use /etc/grafsy/example/grafsy.toml as default"
 else
-  # On debian jessie (systemd 215) it fails if symlink already exists
-  systemctl is-enabled grafsy || systemctl enable grafsy
-  # Check if systemd is up and running, e.g. not in chroot
-  if systemctl 1>/dev/null 2>&1; then
-    systemctl daemon-reload
-    systemctl restart grafsy.service
-  fi
+  deb-systemd-invoke daemon-reload
+  deb-systemd-helper enable grafsy.service
+  deb-systemd-invoke restart grafsy.service
 fi

--- a/packaging/prerm
+++ b/packaging/prerm
@@ -1,9 +1,4 @@
 #!/bin/sh
 
-if [ -x /bin/systemctl ] && [ -d /run/systemd/system ]; then
-  systemctl stop grafsy.service || true
-  systemctl disable grafsy.service || true
-else
-  echo "Systemd not detected, skipping service stop/disable."
-fi
-
+deb-systemd-invoke stop grafsy.service
+deb-systemd-helper disable grafsy.service


### PR DESCRIPTION
Instead of checking if systemd is ready and other shenanigans, just use the helper scripts from Debian that already take care of everything.

The previous systemd checks missed for example the case where a service was masked on purpose, causing package upgrades to straight out fail.